### PR TITLE
Add clusterrolebinding for listing nodes

### DIFF
--- a/workspace.yaml
+++ b/workspace.yaml
@@ -5,6 +5,34 @@ metadata:
   name: $STUDENT
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    acend.ch/purpose: webshell
+  name: acend-webshell
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ${STUDENT}-webshell
+subjects:
+- kind: User
+  name: system:serviceaccount:${STUDENT}-webshell:default
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: acend-webshell
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding 
 metadata:
   name: $STUDENT-rb


### PR DESCRIPTION
This is somewhat strange. There's already a `RoleBinding` (note: not a `ClusterRoleBinding which it should be) that references the `ClusterRole` `cluster-admin`, but this obviously doesn't work as it's e.g. not possible to list nodes. At the same time I'm wondering why users of the webshell should have cluster-admin permissions.

If there's an agreement that we can just add the needed permissions to a separate `ClusterRole` we should do that instead of giving `cluster-admin` as a `ClusterRoleBinding` and remove these `cluster-admin` references alltogether.