### PR TITLE
Create Image Version Tag on release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Build Training and Publish
+name: PR Build
 
 on:
   pull_request:
@@ -26,7 +26,7 @@ jobs:
           username: ${{ secrets.QUAYIO_USERNAME }}
           password: ${{ secrets.QUAYIO_TOKEN }}
       -
-        name: Build Latest Version
+        name: Build PR Version
         uses: docker/build-push-action@v2
         with:
           context: .

--- a/.github/workflows/pr-cleanup.yaml
+++ b/.github/workflows/pr-cleanup.yaml
@@ -1,11 +1,4 @@
-# changeme 
-# Change the following parts to your current installation
-# - Helm Target Namespace
-# - Repository: you might need to change the name of your repository, depending on the choosen name
-# - Secrets
-#   - QUAYIO_API_TOKEN is needed for house keeping and removing old tagged images
-#   - KUBECONFIG_TEST content of the Kubeconfig File, Account must have access to the k8s namespace. It's used in the helm steps
-name: PRCleanup
+name: PR Cleanup
 on:
   pull_request:
     types: [closed]

--- a/.github/workflows/push-main.yaml
+++ b/.github/workflows/push-main.yaml
@@ -1,14 +1,4 @@
-# changeme 
-# Change the following parts to your current installation
-# - entire Docker Build steps accordingly to the amount of different versions or tags your building TRAINING_HUGO_ENV
-#   - Tags
-# - Helm Target Namespace
-# - Name of K8S Deployment to trigger and namespace
-# - Secrets
-#   - QUAYIO_USERNAME and QUAYIO_TOKEN must be set accordingly to your registry, existing users must have access to the repos
-#   - KUBECONFIG content of the Kubeconfig File, Account must have access to the k8s namespace. It's used in the helm steps
-
-name: Publish Main Version
+name: Build latest Version & release Helm Chart
 
 on:
   push:
@@ -68,14 +58,12 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          # changeme
           tags: |
             quay.io/acend/theia:latest
       -
         name: Run vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          # changeme
           image-ref: 'quay.io/acend/theia:latest'
           format: 'table'
           output: 'trivy-results.txt'
@@ -89,44 +77,3 @@ jobs:
         with:
           name: trivy-results-main
           path: trivy-results.txt
-  deploy:
-    needs: [release-helmchart, build]
-    runs-on: ubuntu-latest
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - 
-        name: 'Install Helm'
-        uses: azure/setup-helm@v1
-        with:
-          version: v3.6.2
-      - 
-        name: Install Kubectl
-        uses: azure/setup-kubectl@v1
-        with:
-          version: v1.21.2
-      - 
-        name: Create KUBECONFIG
-        env:
-          KUBE_CONFIG: '${{ secrets.KUBECONFIG }}'
-        run: |
-          mkdir -p $HOME/.kube
-          echo "$KUBE_CONFIG" > $HOME/.kube/config
-      - 
-        name: Deploy Helm Release
-        env:
-          HELM_RELEASE: 'demo-webshell'
-          NAMESPACE: 'acend-webshell'
-          PASSWORD: '${{ secrets.WEBSHELL_TEST_PASSWORD }}'
-        run: |
-          helm upgrade $HELM_RELEASE webshell --install --wait --kubeconfig $HOME/.kube/config  --namespace=$NAMESPACE  --repo=https://acend.github.io/webshell-env/  --set password=$PASSWORD --values=helm-chart/values.yaml --atomic
-      - 
-        name: Redeploy Webshell
-        env:
-          NAMESPACE: 'acend-webshell'
-          HELM_RELEASE: 'demo-webshell'
-        run: |
-          kubectl rollout restart deployment/$HELM_RELEASE --kubeconfig $HOME/.kube/config --namespace $NAMESPACE

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,102 @@
+name: Build & deploy Release Version
+
+on:
+  push:
+    tags:
+    - 'webshell-*' # This is created when push on main when Helm Chart version was changed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to Quay.io Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAYIO_USERNAME }}
+          password: ${{ secrets.QUAYIO_TOKEN }}
+
+      - 
+        name: Get the version # strip away "ref/tags/webshell-"
+        id: get_version
+        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3 | sed 's/webshell-//g')
+
+      -
+        name: Build Release Version
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            quay.io/acend/theia:${{ steps.get_version.outputs.VERSION }}
+      -
+        name: Run vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'quay.io/acend/theia:${{ steps.get_version.outputs.VERSION }}'
+          format: 'table'
+          output: 'trivy-results.txt'
+          exit-code: '0'
+          ignore-unfixed: true
+          vuln-type: 'os'
+          severity: 'CRITICAL,HIGH'
+      -
+        name: Archive vulnerability scan results
+        uses: actions/upload-artifact@v2
+        with:
+          name: trivy-results-main
+          path: trivy-results.txt
+  deploy:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - 
+        name: 'Install Helm'
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.6.2
+      - 
+        name: Install Kubectl
+        uses: azure/setup-kubectl@v1
+        with:
+          version: v1.21.2
+      - 
+        name: Create KUBECONFIG
+        env:
+          KUBE_CONFIG: '${{ secrets.KUBECONFIG }}'
+        run: |
+          mkdir -p $HOME/.kube
+          echo "$KUBE_CONFIG" > $HOME/.kube/config
+      - 
+        name: Deploy Helm Release
+        env:
+          HELM_RELEASE: 'demo-webshell'
+          NAMESPACE: 'acend-webshell'
+          PASSWORD: '${{ secrets.WEBSHELL_TEST_PASSWORD }}'
+        run: |
+          helm upgrade $HELM_RELEASE webshell --install --wait --kubeconfig $HOME/.kube/config  --namespace=$NAMESPACE  --repo=https://acend.github.io/webshell-env/  --set password=$PASSWORD --values=helm-chart/values.yaml --atomic
+      - 
+        name: Redeploy Webshell
+        env:
+          NAMESPACE: 'acend-webshell'
+          HELM_RELEASE: 'demo-webshell'
+        run: |
+          kubectl rollout restart deployment/$HELM_RELEASE --kubeconfig $HOME/.kube/config --namespace $NAMESPACE

--- a/deploy/charts/webshell/Chart.yaml
+++ b/deploy/charts/webshell/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: webshell
 description: A Helm chart to deploy a webshell environment
 type: application
-version: 0.1.11
-appVersion: "latest"
+version: 0.1.12
+appVersion: "0.1.12"


### PR DESCRIPTION
So far only a `latest` and the PR tag was builded for the webshell. As the Deployment in the Helm Chart uses `IfNotPresent` as PullPolicy (by default) this might lead to a redeployment with the same (old) image instead of the newly created image.

Therefore with this PR I introduce versioning for the webshell container image.

With these changes:

* Push to main only creates the `latest` container image tag.
* Push to main creates a new release with a new helm chart when the `version` has changed in `Charts.yaml`. This Action will fail when the release already exists.
* A new release (triggered by the push to main) will build the a container image with the release version as tag and redeploy the demo-webshell.

Note:
* `version` in `Chart.yaml` is used to create the Github release
* `appVersion` in `Chart.yaml` is used as the image tag in the deployment if not overwritten in `values.yaml`