### PR TITLE
chore: migrate Renovate regex manager config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
       "groupName": "{{manager}}"
     }
   ],
-  "regexManagers": [
+  "customManagers": [
     {
       "customType": "regex",
       "description": "Update ARG versions of services in Dockerfiles",


### PR DESCRIPTION
## Summary

Renames the deprecated Renovate `regexManagers` block to `customManagers` while keeping the existing `customType: "regex"` matcher and all current Dockerfile ARG extraction behavior unchanged.

## Why

The Dependency Dashboard currently reports **Config Migration Needed**. This small config-only change should clear the migration warning without touching dependency versions, workflows, credentials, or registry settings.

## Notes

I left the existing `registry.redhat.io` lookup warning alone because that is separate from the config migration and may depend on image availability or registry policy.
